### PR TITLE
Revert scipy dep, document flow to use this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# Chef-Robotics workflow
+
+We use this rosdistro fork to maintain control of the rosdep
+resolutions, both for pinning and to add our own dependencies.
+
+## Adding a dependency or updating from upstream
+
+1. Create a branch from this repo's `master` branch with your change
+  with the name `r.N` where N is an increasing "version number".
+  > NOTE: Once created it will be a protected branch
+
+2. Once created, create a PR in ChefAutonomy (or whatever other repo
+  that uses this) to change the branch pointed to by docker builds.
+
+  Example: https://github.com/chef-robotics/ChefAutonomy/pull/1322
+
+3. Once 2 is accepted and merged, merge your `r.N` branch back into
+  `master`; note that dev machines will still use master as the
+  reference (i.e. rolling release).
+
+# ros/rosdistro
+
 This repo maintains the lists of repositories defining ROS distributions.
 
 It is the implementation of [REP 143](http://ros.org/reps/rep-0143.html)

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3995,14 +3995,8 @@ python-scipy:
   ubuntu:
     artful: [python-scipy]
     artful_python3: [python3-scipy]
-    bionic:
-      pip:
-        depends: [gfortran]
-        packages: [scipy]
-    bionic_python3:
-      pip:
-        depends: [gfortran]
-        packages: [scipy]
+    bionic: [python-scipy]
+    bionic_python3: [python3-scipy]
     lucid: [python-scipy]
     maverick: [python-scipy]
     natty: [python-scipy]


### PR DESCRIPTION
## Commits

### Revert "install scipy from pip instead of apt"
This reverts commit 1ffbd3f3a144df2756d94472d046cf11755718e1.

### Add repo workflow to README

