### PR TITLE
Add Dependency for Google Cloud Storage

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1750,6 +1750,13 @@ python-google-cloud-bigquery-pip:
   ubuntu:
     pip:
       packages: [google-cloud-bigquery]
+python-google-cloud-storage-pip:
+  debian:
+    pip:
+      packages: [google-cloud-storage]
+  ubuntu:
+    pip:
+      packages: [google-cloud-storage]
 python-google-cloud-speech-pip:
   debian:
     pip:


### PR DESCRIPTION
Adding debian and ubuntu mappings for the `google-cloud-storage` library to support https://github.com/chef-robotics/ChefAutonomy/pull/2261 