### PR TITLE
Use Pip as Fabric and Lexicon Package Manager

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1416,7 +1416,7 @@ python-expiringdict:
     pip:
       packages: [expiringdict]
   ubuntu: [python-expiringdict]
-python-fabric:
+python-fabric-pip:
   ubuntu: [fabric]
 python-face-alignment-pip:
   debian:
@@ -2228,7 +2228,7 @@ python-levenshtein:
   fedora: [python-Levenshtein]
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
-python-lexicon:
+python-lexicon-pip:
   ubuntu: [lexicon]
 python-libpcap:
   debian: [python-libpcap]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1417,7 +1417,9 @@ python-expiringdict:
       packages: [expiringdict]
   ubuntu: [python-expiringdict]
 python-fabric-pip:
-  ubuntu: [fabric]
+  ubuntu: 
+    pip:
+      packages: [fabric]
 python-face-alignment-pip:
   debian:
     pip:
@@ -2229,7 +2231,9 @@ python-levenshtein:
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
 python-lexicon-pip:
-  ubuntu: [lexicon]
+  ubuntu: 
+    pip:
+      packages: [lexicon]
 python-libpcap:
   debian: [python-libpcap]
   fedora: [pylibpcap]


### PR DESCRIPTION
#8 missed `pip` and `packages` subfields for the fabric and lexicon packages, which resulted in rosdep attempting to install them via apt and providing incorrect dependencies for `chef_control. 