### PR TITLE
Add network metadata dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4450,10 +4450,6 @@ nasm:
   macports: [nasm]
   opensuse: [nasm]
   ubuntu: [nasm]
-nethogs:
-  ubuntu: [nethogs]
-net-tools:
-  ubuntu: [net-tools]
 nbtscan:
   arch: [nbtscan]
   debian: [nbtscan]
@@ -4472,6 +4468,8 @@ netcdf:
   gentoo: [sci-libs/netcdf, sci-libs/netcdf-cxx, sci-libs/netcdf-fortran]
   macports: [netcdf, netcdf-cxx]
   ubuntu: [libnetcdf-dev]
+nethogs:
+  ubuntu: [nethogs]
 netpbm:
   arch: [netpbm]
   debian: [libnetpbm10-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4450,6 +4450,10 @@ nasm:
   macports: [nasm]
   opensuse: [nasm]
   ubuntu: [nasm]
+nethogs:
+  ubuntu: [nethogs]
+net-tools:
+  ubuntu: [net-tools]
 nbtscan:
   arch: [nbtscan]
   debian: [nbtscan]


### PR DESCRIPTION
Add nethogs and net-tools (for ifconfig) to rosdep to allow importing to chef_node_base for network_metadata_publisher.py. 

Blocking https://github.com/chef-robotics/ChefAutonomy/pull/2395

TODO make a release