### PR TITLE
Add Datadog python client to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1205,6 +1205,10 @@ python-cython-pip:
   ubuntu:
     pip:
       packages: [cython]
+python-datadog-pip:
+  ubuntu:
+    pip:
+      packages: [datadog]
 python-dateutil:
   arch: [python2-dateutil]
   debian: [python-dateutil]


### PR DESCRIPTION
Add [Datadog's Python client library](https://github.com/DataDog/datadogpy) to rosdep.